### PR TITLE
Remove NSSM reference in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Chocolatey package for [Nomad](https://www.nomadproject.io/).
 
-This package installs Nomad as a service, using NSSM as the service wrapper.
+This package installs Nomad as a service.
 
 ## Updating the package
 


### PR DESCRIPTION
Given https://github.com/devblok/chocolatey-nomad/commit/278115262c0d6d35525fb2e7f433ce736398cc3e, NSSM mention in the readme is outdated.